### PR TITLE
Use syscall.Termios for Go 1.1 on Darwin

### DIFF
--- a/bsd.go
+++ b/bsd.go
@@ -1,4 +1,4 @@
-// +build freebsd openbsd netbsd darwin
+// +build freebsd openbsd netbsd
 
 package gopass
 

--- a/nix.go
+++ b/nix.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux darwin
 
 package gopass
 


### PR DESCRIPTION
Reverting previous changes made: 81dffa7044552e36f245913cbeb64f3d19983e94

Tested on Darwin and everything works as expected
