### PR TITLE
Avoid cgo for FreeBSD.

### DIFF
--- a/bsd.go
+++ b/bsd.go
@@ -1,4 +1,4 @@
-// +build freebsd openbsd netbsd
+// +build openbsd netbsd
 
 package gopass
 

--- a/nix.go
+++ b/nix.go
@@ -1,4 +1,4 @@
-// +build linux darwin
+// +build linux darwin freebsd
 
 package gopass
 


### PR DESCRIPTION
crypto/ssh/terminal works fine on FreeBSD (tested
on FreeBSD-10.1 w/ Go1.4.2).

It probably works fine for the other BSDs as well but without
testing it I'll leave the cgo implementation for them alone.