### PR TITLE
Read from pipes on Windows and return system errors

### DIFF
--- a/nix.go
+++ b/nix.go
@@ -9,8 +9,6 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-const lineEnding = "\n"
-
 func getch() (byte, error) {
 	if oldState, err := terminal.MakeRaw(0); err != nil {
 		return 0, err

--- a/pass.go
+++ b/pass.go
@@ -2,7 +2,7 @@ package gopass
 
 import (
 	"errors"
-	"os"
+	"fmt"
 )
 
 var (
@@ -24,7 +24,7 @@ func getPasswd(masked bool) ([]byte, error) {
 		if v, e := getch(); v == 127 || v == 8 {
 			if l := len(pass); l > 0 {
 				pass = pass[:l-1]
-				os.Stdout.Write(bs)
+				fmt.Print(string(bs))
 			}
 		} else if v == 13 || v == 10 {
 			break
@@ -33,13 +33,13 @@ func getPasswd(masked bool) ([]byte, error) {
 			break
 		} else if v != 0 {
 			pass = append(pass, v)
-			os.Stdout.Write(mask)
+			fmt.Print(string(mask))
 		} else if e != nil {
 			err = e
 			break
 		}
 	}
-	os.Stdout.WriteString(lineEnding)
+	fmt.Println()
 	return pass, err
 }
 

--- a/win.go
+++ b/win.go
@@ -2,16 +2,14 @@
 
 package gopass
 
-import "errors"
 import "syscall"
 import "unsafe"
-import "unicode/utf16"
 
 const lineEnding = "\r\n"
 
 func getch() (byte, error) {
 	modkernel32 := syscall.NewLazyDLL("kernel32.dll")
-	procReadConsole := modkernel32.NewProc("ReadConsoleW")
+	procReadFile := modkernel32.NewProc("ReadFile")
 	procGetConsoleMode := modkernel32.NewProc("GetConsoleMode")
 	procSetConsoleMode := modkernel32.NewProc("SetConsoleMode")
 
@@ -28,17 +26,22 @@ func getch() (byte, error) {
 	procSetConsoleMode.Call(uintptr(syscall.Stdin), uintptr(newMode))
 	defer procSetConsoleMode.Call(uintptr(syscall.Stdin), uintptr(mode))
 
-	line := make([]uint16, 1)
+	line := make([]byte, 1)
 	pLine := &line[0]
+	var result uintptr
+	var err error
 	var n uint16
-	procReadConsole.Call(uintptr(syscall.Stdin), uintptr(unsafe.Pointer(pLine)), uintptr(len(line)), uintptr(unsafe.Pointer(&n)))
+	for n < 1 {
+		result, _, err = procReadFile.Call(uintptr(syscall.Stdin),
+			uintptr(unsafe.Pointer(pLine)),
+			uintptr(len(line)),
+			uintptr(unsafe.Pointer(&n)),
+			uintptr(unsafe.Pointer(nil)))
+	}
 
-	b := []byte(string(utf16.Decode(line)))
-
-	// Not sure how this could happen, but it did for someone
-	if len(b) > 0 {
-		return b[0], nil
+	if result > 0 {
+		return line[0], nil
 	} else {
-		return 13, errors.New("Read error")
+		return 13, err
 	}
 }

--- a/win.go
+++ b/win.go
@@ -5,8 +5,6 @@ package gopass
 import "syscall"
 import "unsafe"
 
-const lineEnding = "\r\n"
-
 func getch() (byte, error) {
 	modkernel32 := syscall.NewLazyDLL("kernel32.dll")
 	procReadFile := modkernel32.NewProc("ReadFile")


### PR DESCRIPTION
 - Using ReadFile rather than ReadConsoleW allows you to read from
pipes.  In addition, the documentation for gopass specifies that
UTF-8 is not supported so there is no reason to specifically try
and read Unicode from the console.

 - Properly inspects the return value from the Windows syscall to
see if there was an error or not and returns it. (Non-zero return
value indicates success; the error itself is always non-nil and
would reflect some information about the successful state if there
was not an error).