### PR TITLE
Simplify output calls

### DIFF
--- a/nix.go
+++ b/nix.go
@@ -9,8 +9,6 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-const lineEnding = "\n"
-
 func getch() (byte, error) {
 	if oldState, err := terminal.MakeRaw(0); err != nil {
 		return 0, err

--- a/pass.go
+++ b/pass.go
@@ -2,7 +2,7 @@ package gopass
 
 import (
 	"errors"
-	"os"
+	"fmt"
 )
 
 var (
@@ -24,7 +24,7 @@ func getPasswd(masked bool) ([]byte, error) {
 		if v, e := getch(); v == 127 || v == 8 {
 			if l := len(pass); l > 0 {
 				pass = pass[:l-1]
-				os.Stdout.Write(bs)
+				fmt.Print(string(bs))
 			}
 		} else if v == 13 || v == 10 {
 			break
@@ -33,13 +33,13 @@ func getPasswd(masked bool) ([]byte, error) {
 			break
 		} else if v != 0 {
 			pass = append(pass, v)
-			os.Stdout.Write(mask)
+			fmt.Print(string(mask))
 		} else if e != nil {
 			err = e
 			break
 		}
 	}
-	os.Stdout.WriteString(lineEnding)
+	fmt.Println()
 	return pass, err
 }
 

--- a/win.go
+++ b/win.go
@@ -7,8 +7,6 @@ import "syscall"
 import "unsafe"
 import "unicode/utf16"
 
-const lineEnding = "\r\n"
-
 func getch() (byte, error) {
 	modkernel32 := syscall.NewLazyDLL("kernel32.dll")
 	procReadConsole := modkernel32.NewProc("ReadConsoleW")


### PR DESCRIPTION
 - Removes os.Stdout.WriteX calls in favor of more idiomatic fmt.Print
calls.

 - Removes special handling for Windows line ending when output at the
end of parsing the password.  The rest of go's library uses the basic
`\n` line ending even on Windows and there is not any issue; does not
seem to have a clear benefit to complicate the output of the line.