### PR TITLE
Dont have Windows processes the interrupt signal

### DIFF
--- a/win.go
+++ b/win.go
@@ -15,11 +15,12 @@ var getch = func() (byte, error) {
 	pMode := &mode
 	procGetConsoleMode.Call(uintptr(syscall.Stdin), uintptr(unsafe.Pointer(pMode)))
 
-	var echoMode, lineMode uint32
+	var echoMode, lineMode, procMode uint32
 	echoMode = 4
 	lineMode = 2
+	procMode = 1
 	var newMode uint32
-	newMode = mode &^ (echoMode | lineMode)
+	newMode = mode &^ (echoMode | lineMode | procMode)
 
 	procSetConsoleMode.Call(uintptr(syscall.Stdin), uintptr(newMode))
 	defer procSetConsoleMode.Call(uintptr(syscall.Stdin), uintptr(mode))


### PR DESCRIPTION
 - Changed proccessed_input mode so that we receive the 0x03 byte
rather than the program just exiting.  This way we can still restore
the console mode in Windows.
 - The corresponding change in *nix is unncessary since terminal.MakeRaw
already does this.