### PR TITLE
Handle errors first and disregard byte when error exists

### DIFF
--- a/pass.go
+++ b/pass.go
@@ -47,7 +47,10 @@ func getPasswd(masked bool) ([]byte, error) {
 	}
 
 	for {
-		if v, e := getch(); v == 127 || v == 8 {
+		if v, e := getch(); e != nil {
+			err = e
+			break
+		} else if v == 127 || v == 8 {
 			if l := len(pass); l > 0 {
 				pass = pass[:l-1]
 				fmt.Print(string(bs))
@@ -60,9 +63,6 @@ func getPasswd(masked bool) ([]byte, error) {
 		} else if v != 0 {
 			pass = append(pass, v)
 			fmt.Print(string(mask))
-		} else if e != nil {
-			err = e
-			break
 		}
 	}
 	fmt.Println()


### PR DESCRIPTION
Fixes a problem where error cases were usually simply treated
as `enter` presses on Windows and nil bytes on *nix.  This was
a result of the error case being handled last rather than first.

Any byte that comes back along with an error should be disregarded.

Added test cases that confirm this behavior.