### PR TITLE
Add support for Illumos-derived operating systems

### DIFF
--- a/pass.go
+++ b/pass.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 var defaultGetCh = func() (byte, error) {
@@ -40,11 +38,11 @@ func getPasswd(masked bool) ([]byte, error) {
 		mask = []byte("*")
 	}
 
-	if terminal.IsTerminal(int(os.Stdin.Fd())) {
-		if oldState, err := terminal.MakeRaw(int(os.Stdin.Fd())); err != nil {
+	if isTerminal(os.Stdin.Fd()) {
+		if oldState, err := makeRaw(os.Stdin.Fd()); err != nil {
 			return pass, err
 		} else {
-			defer terminal.Restore(int(os.Stdin.Fd()), oldState)
+			defer restore(os.Stdin.Fd(), oldState)
 		}
 	}
 

--- a/terminal.go
+++ b/terminal.go
@@ -1,0 +1,25 @@
+// +build !solaris
+
+package gopass
+
+import "golang.org/x/crypto/ssh/terminal"
+
+type terminalState struct {
+	state *terminal.State
+}
+
+func isTerminal(fd uintptr) bool {
+	return terminal.IsTerminal(int(fd))
+}
+
+func makeRaw(fd uintptr) (*terminalState, error) {
+	state, err := terminal.MakeRaw(int(fd))
+
+	return &terminalState{
+		state: state,
+	}, err
+}
+
+func restore(fd uintptr, oldState *terminalState) error {
+	return terminal.Restore(int(fd), oldState.state)
+}

--- a/terminal_solaris.go
+++ b/terminal_solaris.go
@@ -1,0 +1,46 @@
+package gopass
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+type terminalState struct {
+	state *unix.Termios
+}
+
+// isTerminal returns true if there is a terminal attached to the given
+// file descriptor.
+// Source: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c
+func isTerminal(fd uintptr) bool {
+	var termio unix.Termio
+	err := unix.IoctlSetTermio(int(fd), unix.TCGETA, &termio)
+	return err == nil
+}
+
+// makeRaw puts the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+// Source: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libast/common/uwin/getpass.c
+func makeRaw(fd uintptr) (*terminalState, error) {
+	oldTermiosPtr, err := unix.IoctlGetTermios(int(fd), unix.TCGETS)
+	if err != nil {
+		return nil, err
+	}
+	oldTermios := *oldTermiosPtr
+
+	newTermios := oldTermios
+	newTermios.Lflag &^= syscall.ECHO | syscall.ECHOE | syscall.ECHOK | syscall.ECHONL
+	if err := unix.IoctlSetTermios(int(fd), unix.TCSETS, &newTermios); err != nil {
+		return nil, err
+	}
+
+	return &terminalState{
+		state: oldTermiosPtr,
+	}, nil
+}
+
+func restore(fd uintptr, oldState *terminalState) error {
+	return unix.IoctlSetTermios(int(fd), unix.TCSETS, oldState.state)
+}


### PR DESCRIPTION
This commit adds support for building on Illumos-derived operating systems by reimplementing the various missing functions from package `golang.org/x/crypto/ssh/terminal` when compiling for the `solaris` GOOS.

The implementations are based on the C in the Illumos libraries. In order to support calling either version of the functions, they are abstracted into a separate file with build tags, where the "non-solaris" version delegates to the `crypto/ssh/terminal` functions.

Regrettably the `crypto/ssh/terminal` functions return a type with private fields which our local implementation cannot construct  - consequently we return an `interface{}` from makeRaw and verify that we have the correct, non-nil type when restoring.