### PR TITLE
GetPasswdX: interface to specify output port

### DIFF
--- a/pass.go
+++ b/pass.go
@@ -12,7 +12,7 @@ type FdReader interface {
 	Fd() uintptr
 }
 
-var defaultGetCh = func(r FdReader) (byte, error) {
+var defaultGetCh = func(r io.Reader) (byte, error) {
 	buf := make([]byte, 1)
 	if n, err := r.Read(buf); n == 0 || err != nil {
 		if err != nil {

--- a/pass_test.go
+++ b/pass_test.go
@@ -55,7 +55,7 @@ func TestGetPasswd(t *testing.T) {
 				t.Fatal(err.Error())
 			}
 
-			result, err := getPasswd(masked, w)
+			result, err := getPasswd("", masked, os.Stdin, w)
 			if err != nil {
 				t.Errorf("Error getting password: %s", err.Error())
 			}
@@ -175,7 +175,7 @@ func pipeBytesToStdin(b []byte) (int, error) {
 // TestGetPasswd_Err tests errors are properly handled from getch()
 func TestGetPasswd_Err(t *testing.T) {
 	var inBuffer *bytes.Buffer
-	getch = func() (byte, error) {
+	getch = func(FdReader) (byte, error) {
 		b, err := inBuffer.ReadByte()
 		if err != nil {
 			return 13, err

--- a/pass_test.go
+++ b/pass_test.go
@@ -175,7 +175,7 @@ func pipeBytesToStdin(b []byte) (int, error) {
 // TestGetPasswd_Err tests errors are properly handled from getch()
 func TestGetPasswd_Err(t *testing.T) {
 	var inBuffer *bytes.Buffer
-	getch = func(FdReader) (byte, error) {
+	getch = func(io.Reader) (byte, error) {
 		b, err := inBuffer.ReadByte()
 		if err != nil {
 			return 13, err

--- a/pass_test.go
+++ b/pass_test.go
@@ -46,7 +46,6 @@ func TestGetPasswd(t *testing.T) {
 
 	// Redirecting output for tests as they print to os.Stdout but we want to
 	// capture and test the output.
-	origStdOut := os.Stdout
 	for _, masked := range []bool{true, false} {
 		for _, d := range ds {
 			pipeBytesToStdin(d.input)
@@ -55,10 +54,8 @@ func TestGetPasswd(t *testing.T) {
 			if err != nil {
 				t.Fatal(err.Error())
 			}
-			os.Stdout = w
 
-			result, err := getPasswd(masked)
-			os.Stdout = origStdOut
+			result, err := getPasswd(masked, w)
 			if err != nil {
 				t.Errorf("Error getting password: %s", err.Error())
 			}


### PR DESCRIPTION
The problem:
A program may want to prompt the user for a password using stderr, while producing useful output in stdout. 
This fails with the current implementation, because the output from GetPasswd will be forcefully written to stdout, mixing with program output and becoming invisible when stdout is redirected in the shell.
The ugly workaround is to temporarily set os.Stdout to point to the desired writer while prompting for the password, which is (besides ugly) unsafe for concurrent operations.

This patch extends the interface to support this usecase.
It adds a writer argument to the `getPasswd` implementation and a new extended interface to expose this argument to clients.
It also removes the aforementioned workaround in the test, taking advantage of the writer argument to collect output.