### PR TITLE
Fix error in ConEmu windows terminal

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -1,4 +1,4 @@
-// +build !solaris
+// +build !solaris !windows
 
 package gopass
 
@@ -13,11 +13,15 @@ func isTerminal(fd uintptr) bool {
 }
 
 func makeRaw(fd uintptr) (*terminalState, error) {
-	state, err := terminal.MakeRaw(int(fd))
+	state, err := terminal.GetState(int(fd))
+	if err != nil {
+		return nil, err
+	}
+	terminal.MakeRaw(int(fd))
 
 	return &terminalState{
 		state: state,
-	}, err
+	}, nil
 }
 
 func restore(fd uintptr, oldState *terminalState) error {

--- a/terminal.go
+++ b/terminal.go
@@ -1,4 +1,4 @@
-// +build !solaris !windows
+// +build !solaris
 
 package gopass
 


### PR DESCRIPTION
In ConEmu environment, "GetConsoleMode" is ok. "SetConsoleMode" is worked and return an error.
It means both IsTerminal(), GetState() which call "GetConsoleMode" is ok, but "MakeRaw()" return nil and an error.